### PR TITLE
Add indicator for private repositories

### DIFF
--- a/app/tentacles/public/css/style.css
+++ b/app/tentacles/public/css/style.css
@@ -117,8 +117,8 @@
   font-size: 1.5em;
 }
 .pr-list {
-  padding-left: .5em;
-  padding-right: .5em;
+  padding-left: 1em;
+  padding-right: 1em;
 }
 .pr-item {
   margin-bottom: 1.2em;
@@ -152,4 +152,13 @@
   color: #fff;
   border-radius: 2px;
   box-shadow: inset 0 -1px 0 rgba(0,0,0,0.12);
+}
+.label-private {
+    font-weight: normal;
+    color: #4c4a42;
+    background-color: #ffefc6;
+}
+.path-divider {
+  margin: 0 0.25em;
+  font-size: 1.2em;
 }

--- a/app/tentacles/views/pulls.erb
+++ b/app/tentacles/views/pulls.erb
@@ -22,7 +22,14 @@
           <p class="lead">This is all the opened Pull Requests that should be reviewed and merged.</p>
           <% pull_request.each do |pr| %>
           <div classs="pr-repo">
-            <div class="pr-repo__link link-blue"><a href="<%= pr[0][:head][:repo][:html_url] %>"><%= pr[0][:head][:repo][:full_name] %></a></div>
+            <div class="pr-repo__link">
+              <a href="<%= pr[0][:head][:repo][:owner][:html_url] %>" class="link-blue"><%= pr[0][:head][:repo][:full_name].split('/').first %></a>
+              <span class="path-divider">/</span>
+              <a href="<%= pr[0][:head][:repo][:html_url] %>" class="link-blue"><%= pr[0][:head][:repo][:full_name].split('/').last %></a>
+              <% if pr[0][:head][:repo][:private] %>
+                <span class="label label-private">Private</span>
+              <% end %>
+            </div>
             <div class="pr-list">
               <% pr.each do |req| %>
                 <div class="pr-item">

--- a/app/tentacles/views/repositories.erb
+++ b/app/tentacles/views/repositories.erb
@@ -27,6 +27,9 @@
                 <input type="checkbox" name="<%= repo[:full_name] %>" value="<%= repo[:url] %>">
                 <%= repo[:full_name] %>
               </label>
+              <% if repo[:private] %>
+                <span class="label label-private">Private</span>
+              <% end %>
             </div><!--end of checkbox -->
             <% end %>
             <div class="repositories-actions">


### PR DESCRIPTION
Added a "Private" label appearing next to the repo name.
Changed repository name in /pulls to split in 3:
- Owner with link to owner page on Github
- Divider '/'
- Repo with link to the repository page on Github
