### PR TITLE
Add Blank state for Pull Requests page

### DIFF
--- a/app/tentacles/controllers/pulls.rb
+++ b/app/tentacles/controllers/pulls.rb
@@ -32,21 +32,24 @@ module Tentacles
         # Get every pull_requests with the repo name
         pull_requests = []
         params.each do |k, _v|
-          pull_requests << client.pull_requests(k)
+          pr = client.pull_requests(k)
+          pull_requests << pr unless pr.nil? || pr.empty?
         end
         # loop throught pull requests to get the labels
         # add labels to the original hash
         pull_requests.each do |pr|
+          next if pr.nil? || pr[0].nil?
           repo = pr[0][:head][:repo][:full_name]
           pr.each do |request|
             issue_number = request[:number]
             labels = client.labels_for_issue(repo, issue_number)
-            request[:labels] = labels
+            request[:labels] = labels if labels
             # Get the comments as well
             comments = client.pull_request_comments(repo, issue_number)
-            request[:comments_count] = comments.count
+            request[:comments_count] = comments.count if comments
           end
         end
+
         erb :pulls, :locals => { :pull_request => pull_requests, :user => client.user }
       end
     end

--- a/app/tentacles/views/pulls.erb
+++ b/app/tentacles/views/pulls.erb
@@ -23,7 +23,15 @@
         <div class="column">
           <h2>Pull requests</h2>
           <p class="lead lead-align">This is all the opened Pull Requests that should be reviewed and merged.</p>
+          <% if pull_request.nil? || pull_request.empty? %>
+            <div class="blankslate">
+              <h3>Nothing to show here.</h3>
+              <p>There is no Pull Request pending for this repositories</p>
+              <p>Please go back to the <a href="/repositories" title="Repositories selection page">Repositories</a> selection.</p>
+            </div>
+          <% end %>
           <% pull_request.each do |pr| %>
+          <% next if pr.nil? || pr.empty? %>
           <div classs="pr-repo">
             <div class="pr-repo__link">
               <a href="<%= pr[0][:head][:repo][:owner][:html_url] %>" class="link-blue"><%= pr[0][:head][:repo][:full_name].split('/').first %></a>
@@ -35,6 +43,7 @@
             </div>
             <div class="pr-list">
               <% pr.each do |req| %>
+                <% next if req.nil? || req.empty? %>
                 <div class="pr-item">
                   <span class="pr-title"><a href="<%= req[:html_url] %>" class="link-gray-dark"><%= req[:title]%></a></span>
                   <span class="labels">


### PR DESCRIPTION
If there is no pull request to display, we display a generic
explaining message.
Added controls for empty or nil values.
