### PR TITLE
[Core] Use Heroku's docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.0-slim
+FROM heroku/heroku:16
 
 RUN apt-get clean && apt-get update -y \
     && apt-get install -y --no-install-recommends git-core build-essential sudo libffi-dev libxml2-dev libssl-dev curl apt-utils\


### PR DESCRIPTION
* Changed the Dockerfile to use Heroku's own docker image, it will help to align dev environment to the one used on Heroku's servers.

https://trello.com/c/RCHeC79b