### PR TITLE
[Core] Handle multiple pages for repositories

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -37,6 +37,7 @@ module Controllers
         visibility_filter: display_filter,
         access_token: access_token
       )
+
       erb :repositories, :locals => { :user => current_user, :repos => repos }
     end
   end

--- a/app/datasources/github/connection.rb
+++ b/app/datasources/github/connection.rb
@@ -13,7 +13,6 @@ module Datasources
       private
 
       def connect(access_token)
-        Octokit.auto_paginate = true
         @connect ||= Octokit::Client.new(
           :access_token => access_token
         )

--- a/app/datasources/github/pagination.rb
+++ b/app/datasources/github/pagination.rb
@@ -1,0 +1,23 @@
+module Datasources
+  module Github
+    ##
+    # Pagination of github results
+    #
+    class Pagination
+      attr_reader :records
+
+      def initialize(records)
+        @records = records
+      end
+
+      def next_pages(last_response)
+        results = @records
+        until last_response.rels[:next].nil?
+          last_response = last_response.rels[:next].get
+          results.concat last_response.data
+        end
+        results
+      end
+    end
+  end
+end

--- a/app/datasources/github/repositories.rb
+++ b/app/datasources/github/repositories.rb
@@ -1,4 +1,5 @@
 require_relative 'connection'
+require_relative 'pagination'
 
 module Datasources
   module Github
@@ -8,9 +9,18 @@ module Datasources
     class Repositories
       include Connection
 
-      def find_repositories(visibility_filter, access_token:)
-        client(access_token)
-          .repositories(nil, :visibility => visibility_filter)
+      PER_PAGE = Integer(ENV['DEFAULT_PER_PAGE'] || 100)
+
+      def find_repositories(filter, access_token:, per_page: PER_PAGE)
+        github = client(access_token)
+        records = github.repositories(
+          nil,
+          :visibility => filter,
+          :per_page => per_page
+        )
+        return [] unless records
+        pagination = Pagination.new(records)
+        pagination.next_pages(github.last_response)
       end
     end
   end

--- a/app/utils/cache.rb
+++ b/app/utils/cache.rb
@@ -6,7 +6,7 @@ module Utils
   # Cache utils
   #
   module Cache
-    DEFAULT_TTL = 2 * 60 # 25 minutes
+    DEFAULT_TTL = 25 * 60 # 25 minutes
     CACHE_TTL = Integer(ENV['CACHE_TTL'] || DEFAULT_TTL)
 
     ##
@@ -17,6 +17,7 @@ module Utils
     # @param block[Block] The block to yeld if there is no value in cache
     #
     def load_from_cache(key, ttl: CACHE_TTL, &block)
+      return yield block if cache_disabled?
       cached_result = read_cache_value(key)
       return cached_result if cache_exists?(key)
 
@@ -25,17 +26,40 @@ module Utils
       write_cache_value(key, ttl, result)
     end
 
+    ##
+    # Write a value in the cache.
+    #
+    # @param key[String] the namespace of the key in the cache.
+    # @param ttl[Integer] the time to live of the key
+    # @param value[Any] The value to write in the cache:
+    # It's serialized so it can be any format.
+    #
     def write_cache_value(key, ttl, value)
       Redis.current.setex(key, ttl, cache_serialize(value))
       value
     end
 
+    ##
+    # Read a value from the cache.
+    #
+    # @param key[String] The key we want to retrieve from the cache.
+    #
+    # @result [Any] Deserialized value from the cache.
+    #
     def read_cache_value(key)
       return unless key && cache_exists?(key)
       value = Redis.current.get(key)
       value.nil? ? nil : cache_deserialize(value)
     end
 
+    ##
+    # Define the cache key prefix.
+    #
+    # @param key[String] the key to add to the cache.
+    # @param attributes[Array] List of optionnal parameters.
+    #
+    # @result [String] SHA256 of the key + attributes
+    #
     def cache_key(key, *attributes)
       prefix = "#{ENV['CACHE_PREFIX']}:#{key}"
       args = attributes.join('-')
@@ -43,6 +67,10 @@ module Utils
     end
 
     private
+
+    def cache_disabled?
+      ENV['DISABLE_CACHE'].to_s == 'true'
+    end
 
     def cache_exists?(key)
       Redis.current.exists(key)


### PR DESCRIPTION
* Retrieve and concatenate the results for repositories list if github paginate the results.
* Added an helper class to handle github pagination.
* Added a feature flag to be able to disable the cache if needed.
* Cache default TTL is now 25 minutes.

https://trello.com/c/8tjRrtOK
https://trello.com/c/0TPp7sns