### PR TITLE
Use APP_ENV over SINATRA_ENV environment variable

### DIFF
--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <link rel="stylesheet" type="text/css" href="css/primer.min.css">
-    <% if ENV['SINATRA_ENV'] == 'production' %>
+    <% if ENV['APP_ENV'] == 'production' %>
     <link rel="stylesheet" type="text/css" href="css/style.min.css">
     <% else %>
     <link rel="stylesheet" type="text/css" href="css/style.css">

--- a/app/views/pulls.erb
+++ b/app/views/pulls.erb
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <link rel="stylesheet" type="text/css" href="css/primer.min.css">
-    <% if ENV['SINATRA_ENV'] == 'production' %>
+    <% if ENV['APP_ENV'] == 'production' %>
     <link rel="stylesheet" type="text/css" href="css/style.min.css">
     <% else %>
     <link rel="stylesheet" type="text/css" href="css/style.css">

--- a/app/views/repositories.erb
+++ b/app/views/repositories.erb
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <link rel="stylesheet" type="text/css" href="css/primer.min.css">
-    <% if ENV['SINATRA_ENV'] == 'production' %>
+    <% if ENV['APP_ENV'] == 'production' %>
     <link rel="stylesheet" type="text/css" href="css/style.min.css">
     <% else %>
     <link rel="stylesheet" type="text/css" href="css/style.css">
@@ -88,7 +88,7 @@
       </div><!-- end of columns -->
     </div><!-- end of container -->
     <script src="js/bliss.min.js"></script>
-    <% if ENV['SINATRA_ENV'] == 'production' %>
+    <% if ENV['APP_ENV'] == 'production' %>
     <script src="js/scripts.min.js"></script>
     <% else %>
     <script src="js/scripts.js"></script>

--- a/config.ru
+++ b/config.ru
@@ -2,10 +2,10 @@ require 'dotenv'
 require 'rack'
 require 'rack/session/redis'
 
-ENV['SINATRA_ENV'] ||= 'development'
+ENV['APP_ENV'] ||= 'development'
 
 require 'bundler/setup'
-Bundler.require(:default, ENV['SINATRA_ENV'])
+Bundler.require(:default, ENV['APP_ENV'])
 
 use Rack::Session::Redis,
     redis_server: "#{ENV.fetch('REDIS_URL')}/0/rack:session",

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -5,3 +5,4 @@ threads threads_count, threads_count
 rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
+environment ENV['APP_ENV']  || 'development'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace the SINATRA_ENV by the APP_ENV variable, according to Sinatra's configuration page (deprecation of RACK_ENV variable).
Using SINATRA_ENV create an issue with serving assets like we are always in development environment.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
- Start the app (docker-compose up) and got the the start page: localhost:4011
- Open the developer tools of the browser, see the assets served are not minified.
<!--- Please link to the issue here: -->
Issue: https://github.com/jveillet/tentacles/issues/47

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to use the new Sinatra APP_ENV variable to be able to test on which environment we are.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Put APP_ENV = development in the dotenv, and started the app. The assets are the dev ones (not minified).
- Put APP_ENV = production in the dotenv, and started the app. The assets are the prod ones (minified).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
