### PR TITLE
[ISSUE-67] Use cookie to share selected repos between pages

### DIFF
--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -134,26 +134,14 @@ $.ready().then(function() {
 
   /*
    * Verify if some repository is selected
-   * Submit the form and move on /pulls.
+   * Submit the form to store selection
+   * Redirect to destination
    */
-  validateRepoSelectionPulls = function() {
+  storeSelectionAndRedirect = function(destination) {
     if (checkRepoCheckboxes() == false) {
       displayNoRepoSelectedWarning();
     } else {
-      document.forms["repoForm"].action="/pulls";
-      document.forms["repoForm"].submit();
-    }
-  }
-
-  /*
-   * Verify if some repository is selected.
-   * Submit the form and and move on /stats.
-   */
-  validateRepoSelectionStats = function() {
-    if (checkRepoCheckboxes() == false) {
-      displayNoRepoSelectedWarning();
-    } else {
-      document.forms["repoForm"].action="/stats";
+      document.forms["repoForm"].action="/repositories/selection?redirect=" + destination;
       document.forms["repoForm"].submit();
     }
   }

--- a/tentacles/lib/controllers/application_controller.rb
+++ b/tentacles/lib/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 require 'helpers/state'
 require 'sinatra/base'
+require "sinatra/cookies"
 
 module Controllers
   ##

--- a/tentacles/lib/controllers/pulls_controller.rb
+++ b/tentacles/lib/controllers/pulls_controller.rb
@@ -29,10 +29,10 @@ module Controllers
       logout unless current_user
     end
 
-    post '/pulls' do
+    get '/pulls' do
       pull_requests_groups = []
 
-      params[:repos].each do |repo|
+      selected_repos!.each do |repo|
         next unless repo && !repo.empty?
         issues = find_issues(repo)
         pull_requests_groups << issues unless !issues || issues.empty?

--- a/tentacles/lib/controllers/repositories_controller.rb
+++ b/tentacles/lib/controllers/repositories_controller.rb
@@ -52,8 +52,14 @@ module Controllers
 
       erb :repositories, locals: {
         user: current_user,
-        repos: repos
+        repos: repos,
+        selected_repos: selected_repos
       }
+    end
+
+    post '/repositories/selection' do
+      cookies[:repos] = params[:repos]
+      redirect to(params[:redirect])
     end
   end
 end

--- a/tentacles/lib/controllers/stats_controller.rb
+++ b/tentacles/lib/controllers/stats_controller.rb
@@ -37,10 +37,10 @@ module Controllers
       logout unless current_user
     end
 
-    post '/stats' do
+    get '/stats' do
       pull_requests_groups = []
 
-      params[:repos].each do |repo|
+      selected_repos!.each do |repo|
         next unless repo && !repo.empty?
         issues = find_closed_issues_and_comments_by_repo(repo)
         pull_requests_groups << issues unless !issues || issues.empty?

--- a/tentacles/lib/helpers/repositories.rb
+++ b/tentacles/lib/helpers/repositories.rb
@@ -7,6 +7,8 @@ module Helpers
   # Repositories helper
   #
   module Repositories
+    include Sinatra::Cookies
+
     def find_issues(repo)
       github_issues.find_issues_by_repo(
         repo, access_token: access_token
@@ -89,6 +91,15 @@ module Helpers
           find_repo_and_total_number_of_comments(pull_requests)[1]
       end
       count_hash
+    end
+    
+    def selected_repos!
+      redirect to('/repositories') unless cookies[:repos]
+      selected_repos
+    end
+
+    def selected_repos
+      cookies[:repos]&.split('&').to_a
     end
   end
 end

--- a/tentacles/lib/views/repositories.erb
+++ b/tentacles/lib/views/repositories.erb
@@ -69,7 +69,8 @@
             <% next unless repo %>
             <div class="form-checkbox">
               <label class="js-repo-item">
-                <input type="checkbox" name="repos[]" value="<%= repo[:full_name] %>" class="isRepoCheckBox repo-list__item" data-private="<%= repo[:private] %>">
+                <input type="checkbox" name="repos[]" value="<%= repo[:full_name] %>" class="isRepoCheckBox repo-list__item" 
+                      data-private="<%= repo[:private] %>" <%= selected_repos.include?(repo[:full_name]) ? 'checked' : '' %> >
                 <%= repo[:full_name] %>
                 <% if repo[:private] %>
                   <span class="label label-private">Private</span>
@@ -79,8 +80,8 @@
             <% end %>
             <% if !repos.nil? && !repos.empty? %>
             <div class="repo-actions">
-              <button type="button" class="btn btn-success" onClick="javascript:validateRepoSelectionPulls()">Show Pull Requests</button>
-              <button type="button" class="btn btn-success" onClick="javascript:validateRepoSelectionStats()">Show Statistics </button>
+              <button type="button" class="btn btn-success" onClick="javascript:storeSelectionAndRedirect('/pulls')">Show Pull Requests</button>
+              <button type="button" class="btn btn-success" onClick="javascript:storeSelectionAndRedirect('/stats')">Show Statistics </button>
               <div id="uncheckedMessage" style="display:none" class="repo-error">Please select at least one repository</div>
             </div><!-- end of actions -->
             <% end %>


### PR DESCRIPTION
## Description
Store the selected repos on a cookie to share it between pages and avoid using POST verb to display the different UIs

## Related Issue
https://github.com/jveillet/tentacles/issues/67

## How Has This Been Tested?
Manually

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.